### PR TITLE
SpatialPoint constructor with parameters is fixed

### DIFF
--- a/Source/Sitecore.ContentSearch.Spatial.DataTypes/SpatialPoint.cs
+++ b/Source/Sitecore.ContentSearch.Spatial.DataTypes/SpatialPoint.cs
@@ -22,7 +22,7 @@ namespace Sitecore.ContentSearch.Spatial.DataTypes
             var strLat = tokens[0].Trim();
             var strLon = tokens[1].Trim();
             Lat = double.Parse(strLat);
-            Lon = double.Parse(strLat);
+            Lon = double.Parse(strLon);
         }
 
         protected string RawValue { get; set; }


### PR DESCRIPTION
It populates both latitude and longitude properties correctly now